### PR TITLE
feat: update burn/liquidity charts to subgraph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pursetoken",
       "version": "0.1.0",
       "dependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@emotion/react": "^11.11.1",
         "@openzeppelin/contracts": "^4.0.0-beta.0",
         "@openzeppelin/contracts-upgradeable": "^4.3.0",
@@ -872,9 +873,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -2126,6 +2135,18 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Purse Token",
   "author": "",
   "dependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@emotion/react": "^11.11.1",
     "@openzeppelin/contracts": "^4.0.0-beta.0",
     "@openzeppelin/contracts-upgradeable": "^4.3.0",

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -1,18 +1,25 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import Popup from "reactjs-popup";
-import {BsFillQuestionCircleFill} from "react-icons/bs";
+import { BsFillQuestionCircleFill } from "react-icons/bs";
 import MediaQuery from "react-responsive";
-import {Area, AreaChart, CartesianGrid, Tooltip, XAxis, YAxis,} from "recharts";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
-import {IoStar} from "react-icons/io5";
-import {formatUnits} from "ethers/lib/utils";
-import {BigNumber} from "ethers";
+import { IoStar } from "react-icons/io5";
+import { formatUnits } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
 import * as Constants from "../../constants";
-import {Loading} from "../Loading";
-import {usePursePrice} from "../state/PursePrice/hooks";
-import {useContract} from "../state/contract/hooks";
-import {DataFormater, formatBigNumber, NumberFormatter} from "../utils";
-import {Bounce} from "react-awesome-reveal";
+import { Loading } from "../Loading";
+import { usePursePrice } from "../state/PursePrice/hooks";
+import { useContract } from "../state/contract/hooks";
+import { DataFormater, formatBigNumber, NumberFormatter } from "../utils";
+import { Bounce } from "react-awesome-reveal";
 
 interface CustomTooltipProps {
   payload?: any[];
@@ -22,7 +29,7 @@ interface CustomTooltipProps {
 export default function Main() {
   const [selectedTab, setSelectedTab] = useState("main");
   const [PURSEPrice] = usePursePrice();
-  const {restakingFarm, purseTokenUpgradable} = useContract();
+  const { restakingFarm, purseTokenUpgradable } = useContract();
 
   const [purseTokenTotalSupply, setPurseTokenTotalSupply] = useState<BigNumber>(
     BigNumber.from("0")
@@ -51,10 +58,10 @@ export default function Main() {
   const [isFetchFarmDataLoading, setIsFetchFarmDataLoading] = useState(true);
 
   const CustomTick = (propsCustomTick: any) => {
-    const {x, y, payload} = propsCustomTick;
+    const { x, y, payload } = propsCustomTick;
     const date = new Date(payload.value);
     const year = date.getFullYear();
-    const month = date.toLocaleString("en-US", {month: "short"});
+    const month = date.toLocaleString("en-US", { month: "short" });
 
     return (
       <g transform={`translate(${x},${y})`}>
@@ -68,12 +75,12 @@ export default function Main() {
     );
   };
 
-  const CustomTooltip: React.FC<CustomTooltipProps> = ({payload, label}) => {
+  const CustomTooltip: React.FC<CustomTooltipProps> = ({ payload, label }) => {
     if (payload && payload.length) {
       const value = parseFloat(payload[0].value);
       const date = new Date(label as any);
       const year = date.getFullYear();
-      const month = date.toLocaleString("en-US", {month: "long"});
+      const month = date.toLocaleString("en-US", { month: "long" });
       const day = date.getDate();
       const formattedValue = value.toLocaleString("en-US", {
         maximumFractionDigits: 2,
@@ -152,13 +159,13 @@ export default function Main() {
         (resp) => resp.json()
       );
       cumulateTransferJson.forEach((item: { Sum: string; Date: string }) =>
-        _cumulateTransfer.push({Sum: parseFloat(item.Sum), Date: item.Date})
+        _cumulateTransfer.push({ Sum: parseFloat(item.Sum), Date: item.Date })
       );
       const cumulateBurnJson: any = await cumulateBurnResponse.then((resp) =>
         resp.json()
       );
       cumulateBurnJson.forEach((item: { Sum: string; Date: string }) =>
-        _cumulateBurn.push({Sum: parseFloat(item.Sum), Date: item.Date})
+        _cumulateBurn.push({ Sum: parseFloat(item.Sum), Date: item.Date })
       );
       setCumulateTransfer(_cumulateTransfer);
       setCumulateBurn(_cumulateBurn);
@@ -205,24 +212,24 @@ export default function Main() {
     return (
       <div className="card mb-4 cardbody">
         <div className="card-body center">
-          <table className="textWhiteSmall" style={{width: "100%"}}>
+          <table className="textWhiteSmall" style={{ width: "100%" }}>
             <thead>
-            <tr>
-              <th scope="col">Market Cap</th>
-              <th scope="col">
-                Circulating Supply{" "}
-                <span className="">
+              <tr>
+                <th scope="col">Market Cap</th>
+                <th scope="col">
+                  Circulating Supply{" "}
+                  <span className="">
                     <Popup
                       trigger={(open) => (
-                        <span style={{position: "relative", top: "-1px"}}>
-                          <BsFillQuestionCircleFill size={10}/>
+                        <span style={{ position: "relative", top: "-1px" }}>
+                          <BsFillQuestionCircleFill size={10} />
                         </span>
                       )}
                       on="hover"
                       position="bottom center"
                       offsetY={-23}
                       offsetX={0}
-                      contentStyle={{padding: "3px"}}
+                      contentStyle={{ padding: "3px" }}
                     >
                       <span className="textInfo">
                         {" "}
@@ -230,67 +237,67 @@ export default function Main() {
                       </span>
                     </Popup>
                   </span>
-              </th>
-              <th scope="col">PURSE Token Price</th>
-            </tr>
+                </th>
+                <th scope="col">PURSE Token Price</th>
+              </tr>
             </thead>
             <tbody>
-            {isFetchMainDataLoading ? (
-              <tr>
-                <td>
-                  <Loading/>
-                </td>
-                <td>
-                  <Loading/>
-                </td>
-                <td>
-                  <Loading/>
-                </td>
-              </tr>
-            ) : (
-              <tr>
-                <td>
-                  $
-                  {(
-                    parseFloat(formatUnits(purseTokenTotalSupply, "ether")) *
-                    PURSEPrice
-                  ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-                </td>
-                <td>
-                  {parseFloat(
-                    formatUnits(purseTokenTotalSupply, "ether")
-                  ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-                </td>
-                <td>
-                  $
-                  {parseFloat(PURSEPrice.toString()).toLocaleString("en-US", {
-                    maximumFractionDigits: 6,
-                  })}
-                </td>
-              </tr>
-            )}
+              {isFetchMainDataLoading ? (
+                <tr>
+                  <td>
+                    <Loading />
+                  </td>
+                  <td>
+                    <Loading />
+                  </td>
+                  <td>
+                    <Loading />
+                  </td>
+                </tr>
+              ) : (
+                <tr>
+                  <td>
+                    $
+                    {(
+                      parseFloat(formatUnits(purseTokenTotalSupply, "ether")) *
+                      PURSEPrice
+                    ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                  </td>
+                  <td>
+                    {parseFloat(
+                      formatUnits(purseTokenTotalSupply, "ether")
+                    ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                  </td>
+                  <td>
+                    $
+                    {parseFloat(PURSEPrice.toString()).toLocaleString("en-US", {
+                      maximumFractionDigits: 6,
+                    })}
+                  </td>
+                </tr>
+              )}
             </tbody>
             <thead>
-            <tr>
-              <td></td>
-            </tr>
+              <tr>
+                <td></td>
+              </tr>
             </thead>
             <thead>
-            <tr>
-              <th scope="col">
-                Burn{" "}
-                <span className="">
+              <tr>
+                <th scope="col">
+                  Burn{" "}
+                  <span className="">
                     <Popup
                       trigger={(open) => (
-                        <span style={{position: "relative", top: "-1px"}}>
-                          <BsFillQuestionCircleFill size={10}/>
+                        <span style={{ position: "relative", top: "-1px" }}>
+                          <BsFillQuestionCircleFill size={10} />
                         </span>
                       )}
                       on="hover"
                       position="right center"
                       offsetY={-23}
                       offsetX={0}
-                      contentStyle={{padding: "1px"}}
+                      contentStyle={{ padding: "1px" }}
                     >
                       <span className="textInfo">
                         {" "}
@@ -298,22 +305,22 @@ export default function Main() {
                       </span>
                     </Popup>
                   </span>
-              </th>
+                </th>
 
-              <th scope="col">
-                Distribution{" "}
-                <span className="">
+                <th scope="col">
+                  Distribution{" "}
+                  <span className="">
                     <Popup
                       trigger={(open) => (
-                        <span style={{position: "relative", top: "-1px"}}>
-                          <BsFillQuestionCircleFill size={10}/>
+                        <span style={{ position: "relative", top: "-1px" }}>
+                          <BsFillQuestionCircleFill size={10} />
                         </span>
                       )}
                       on="hover"
                       position="bottom center"
                       offsetY={-23}
                       offsetX={0}
-                      contentStyle={{padding: "1px"}}
+                      contentStyle={{ padding: "1px" }}
                     >
                       <span className="textInfo">
                         {" "}
@@ -321,22 +328,22 @@ export default function Main() {
                       </span>
                     </Popup>
                   </span>
-              </th>
+                </th>
 
-              <th scope="col">
-                Liquidity{" "}
-                <span className="">
+                <th scope="col">
+                  Liquidity{" "}
+                  <span className="">
                     <Popup
                       trigger={(open) => (
-                        <span style={{position: "relative", top: "-1px"}}>
-                          <BsFillQuestionCircleFill size={10}/>
+                        <span style={{ position: "relative", top: "-1px" }}>
+                          <BsFillQuestionCircleFill size={10} />
                         </span>
                       )}
                       on="hover"
                       position="left center"
                       offsetY={-23}
                       offsetX={0}
-                      contentStyle={{padding: "1px"}}
+                      contentStyle={{ padding: "1px" }}
                     >
                       <span className="textInfo">
                         {" "}
@@ -344,69 +351,69 @@ export default function Main() {
                       </span>
                     </Popup>
                   </span>
-              </th>
-            </tr>
+                </th>
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <th scope="col">(Total)</th>
-              <th scope="col">(Total)</th>
-              <th scope="col">(Total)</th>
-            </tr>
+              <tr>
+                <th scope="col">(Total)</th>
+                <th scope="col">(Total)</th>
+                <th scope="col">(Total)</th>
+              </tr>
             </tbody>
             <tbody>
-            {isFetchMainDataLoading ? (
-              <tr>
-                <td>
-                  <Loading/>
-                </td>
-                <td>
-                  <Loading/>
-                </td>
-                <td>
-                  <Loading/>
-                </td>
-              </tr>
-            ) : (
-              <tr>
-                <td>
-                  {parseFloat(
-                    formatUnits(totalBurnAmount, "ether")
-                  ).toLocaleString("en-US", {
-                    maximumFractionDigits: 0,
-                  })}{" "}
-                  / ${" "}
-                  {(
-                    parseFloat(formatUnits(totalBurnAmount, "ether")) *
-                    PURSEPrice
-                  ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-                </td>
-                <td>
-                  {parseFloat(
-                    formatUnits(totalTransferAmount, "ether")
-                  ).toLocaleString("en-US", {
-                    maximumFractionDigits: 0,
-                  })}{" "}
-                  / ${" "}
-                  {(
-                    parseFloat(formatUnits(totalTransferAmount, "ether")) *
-                    PURSEPrice
-                  ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-                </td>
-                <td>
-                  {parseFloat(
-                    formatUnits(totalTransferAmount, "ether")
-                  ).toLocaleString("en-US", {
-                    maximumFractionDigits: 0,
-                  })}{" "}
-                  / ${" "}
-                  {(
-                    parseFloat(formatUnits(totalTransferAmount, "ether")) *
-                    PURSEPrice
-                  ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-                </td>
-              </tr>
-            )}
+              {isFetchMainDataLoading ? (
+                <tr>
+                  <td>
+                    <Loading />
+                  </td>
+                  <td>
+                    <Loading />
+                  </td>
+                  <td>
+                    <Loading />
+                  </td>
+                </tr>
+              ) : (
+                <tr>
+                  <td>
+                    {parseFloat(
+                      formatUnits(totalBurnAmount, "ether")
+                    ).toLocaleString("en-US", {
+                      maximumFractionDigits: 0,
+                    })}{" "}
+                    / ${" "}
+                    {(
+                      parseFloat(formatUnits(totalBurnAmount, "ether")) *
+                      PURSEPrice
+                    ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                  </td>
+                  <td>
+                    {parseFloat(
+                      formatUnits(totalTransferAmount, "ether")
+                    ).toLocaleString("en-US", {
+                      maximumFractionDigits: 0,
+                    })}{" "}
+                    / ${" "}
+                    {(
+                      parseFloat(formatUnits(totalTransferAmount, "ether")) *
+                      PURSEPrice
+                    ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                  </td>
+                  <td>
+                    {parseFloat(
+                      formatUnits(totalTransferAmount, "ether")
+                    ).toLocaleString("en-US", {
+                      maximumFractionDigits: 0,
+                    })}{" "}
+                    / ${" "}
+                    {(
+                      parseFloat(formatUnits(totalTransferAmount, "ether")) *
+                      PURSEPrice
+                    ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                  </td>
+                </tr>
+              )}
             </tbody>
             {/*<thead>*/}
             {/*<tr>*/}
@@ -481,103 +488,103 @@ export default function Main() {
         <div className="card-body center">
           <table
             className="textWhiteSmall text-center"
-            style={{width: "100%"}}
+            style={{ width: "100%" }}
           >
             <thead>
-            <tr>
-              <th scope="col">Total Pool</th>
-              <th scope="col">PURSE Token Total Supply</th>
-              <th scope="col">Farm's PURSE Reward</th>
-            </tr>
+              <tr>
+                <th scope="col">Total Pool</th>
+                <th scope="col">PURSE Token Total Supply</th>
+                <th scope="col">Farm's PURSE Reward</th>
+              </tr>
             </thead>
             <tbody>
-            {isFetchFarmDataLoading ? (
-              <tr>
-                <td>
-                  <Loading/>
-                </td>
-                <td>
-                  <Loading/>
-                </td>
-                <td>
-                  <Loading/>
-                </td>
-              </tr>
-            ) : (
-              <tr>
-                <td>{poolLength.toString()}</td>
-                <td>
-                  {parseFloat(
-                    formatBigNumber(purseTokenTotalSupply, "ether")
-                  ).toLocaleString("en-US", {
-                    maximumFractionDigits: 0,
-                  })}{" "}
-                  Purse
-                </td>
-                <td>
-                  {parseFloat(
-                    formatBigNumber(totalRewardPerBlock, "ether")
-                  ).toLocaleString("en-US", {
-                    maximumFractionDigits: 3,
-                  })}{" "}
-                  Purse per block
-                </td>
-              </tr>
-            )}
+              {isFetchFarmDataLoading ? (
+                <tr>
+                  <td>
+                    <Loading />
+                  </td>
+                  <td>
+                    <Loading />
+                  </td>
+                  <td>
+                    <Loading />
+                  </td>
+                </tr>
+              ) : (
+                <tr>
+                  <td>{poolLength.toString()}</td>
+                  <td>
+                    {parseFloat(
+                      formatBigNumber(purseTokenTotalSupply, "ether")
+                    ).toLocaleString("en-US", {
+                      maximumFractionDigits: 0,
+                    })}{" "}
+                    Purse
+                  </td>
+                  <td>
+                    {parseFloat(
+                      formatBigNumber(totalRewardPerBlock, "ether")
+                    ).toLocaleString("en-US", {
+                      maximumFractionDigits: 3,
+                    })}{" "}
+                    Purse per block
+                  </td>
+                </tr>
+              )}
             </tbody>
             <thead>
-            <tr>
-              <td></td>
-            </tr>
+              <tr>
+                <td></td>
+              </tr>
             </thead>
             <thead>
-            <tr>
-              <th scope="col">Farm's Cap Reward Token</th>
-              <th scope="col">Farm's Minted Reward Token</th>
-              <th scope="col">Farm's PURSE Balance</th>
-            </tr>
+              <tr>
+                <th scope="col">Farm's Cap Reward Token</th>
+                <th scope="col">Farm's Minted Reward Token</th>
+                <th scope="col">Farm's PURSE Balance</th>
+              </tr>
             </thead>
             <tbody>
-            {isFetchFarmDataLoading ? (
-              <tr>
-                <td>
-                  <Loading/>
-                </td>
-                <td>
-                  <Loading/>
-                </td>
-                <td>
-                  <Loading/>
-                </td>
-              </tr>
-            ) : (
-              <tr>
-                <td>
-                  {parseFloat(
-                    formatBigNumber(poolCapRewardToken, "ether")
-                  ).toLocaleString("en-US", {
-                    maximumFractionDigits: 0,
-                  })}{" "}
-                  Purse
-                </td>
-                <td>
-                  {parseFloat(
-                    formatBigNumber(poolMintedRewardToken, "ether")
-                  ).toLocaleString("en-US", {
-                    maximumFractionDigits: 0,
-                  })}{" "}
-                  Purse
-                </td>
-                <td>
-                  {parseFloat(
-                    formatBigNumber(poolRewardToken, "ether")
-                  ).toLocaleString("en-US", {
-                    maximumFractionDigits: 0,
-                  })}{" "}
-                  Purse
-                </td>
-              </tr>
-            )}
+              {isFetchFarmDataLoading ? (
+                <tr>
+                  <td>
+                    <Loading />
+                  </td>
+                  <td>
+                    <Loading />
+                  </td>
+                  <td>
+                    <Loading />
+                  </td>
+                </tr>
+              ) : (
+                <tr>
+                  <td>
+                    {parseFloat(
+                      formatBigNumber(poolCapRewardToken, "ether")
+                    ).toLocaleString("en-US", {
+                      maximumFractionDigits: 0,
+                    })}{" "}
+                    Purse
+                  </td>
+                  <td>
+                    {parseFloat(
+                      formatBigNumber(poolMintedRewardToken, "ether")
+                    ).toLocaleString("en-US", {
+                      maximumFractionDigits: 0,
+                    })}{" "}
+                    Purse
+                  </td>
+                  <td>
+                    {parseFloat(
+                      formatBigNumber(poolRewardToken, "ether")
+                    ).toLocaleString("en-US", {
+                      maximumFractionDigits: 0,
+                    })}{" "}
+                    Purse
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>
@@ -588,10 +595,10 @@ export default function Main() {
   const renderFullTable = () => {
     return (
       <>
-        <div style={{display: selectedTab === "main" ? "block" : "none"}}>
+        <div style={{ display: selectedTab === "main" ? "block" : "none" }}>
           {renderFullMainTable()}
         </div>
-        <div style={{display: selectedTab === "farm" ? "block" : "none"}}>
+        <div style={{ display: selectedTab === "farm" ? "block" : "none" }}>
           {renderFullFarmTable()}
         </div>
         {/* <div style={{display: selectedTab === "vault" ? "block" : "none"}}>
@@ -612,13 +619,13 @@ export default function Main() {
       >
         <label
           className="textWhite center mb-2 pt-4"
-          style={{fontSize: "40px", textAlign: "center"}}
+          style={{ fontSize: "40px", textAlign: "center" }}
         >
           <big>
             <b>CHARTS</b>
           </big>
         </label>
-        <div className="row center" style={{gap: "20px"}}>
+        <div className="row center" style={{ gap: "20px" }}>
           <div>
             {/* <AreaChart width={460} height={300} data={cumulateBurn}>
         <XAxis dataKey="Date" tick={{fontSize: 14}} stroke="#A9A9A9"/>
@@ -630,7 +637,7 @@ export default function Main() {
       </AreaChart><li style={{color:'transparent'}}/> */}
             <div
               className={`common-title`}
-              style={{marginBottom: "40px", textAlign: "center"}}
+              style={{ marginBottom: "40px", textAlign: "center" }}
             >
               Burn
             </div>
@@ -646,9 +653,9 @@ export default function Main() {
             >
               <defs>
                 <linearGradient id="Burn" x1="0" y1="0" x2="1" y2="1">
-                  <stop offset="10%" stopColor="#fcdb5b" stopOpacity={0.8}/>
-                  <stop offset="50%" stopColor="#f7e01e" stopOpacity={0.1}/>
-                  <stop offset="100%" stopColor="#ffe95b" stopOpacity={0.1}/>
+                  <stop offset="10%" stopColor="#fcdb5b" stopOpacity={0.8} />
+                  <stop offset="50%" stopColor="#f7e01e" stopOpacity={0.1} />
+                  <stop offset="100%" stopColor="#ffe95b" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <XAxis
@@ -661,7 +668,7 @@ export default function Main() {
               <YAxis
                 axisLine={false}
                 tickFormatter={DataFormater}
-                tick={{fontSize: 16}}
+                tick={{ fontSize: 16 }}
                 stroke="#000"
               />
               <CartesianGrid
@@ -683,13 +690,13 @@ export default function Main() {
                 }}
               />
               <Tooltip
-                content={<CustomTooltip/>}
+                content={<CustomTooltip />}
                 cursor={{
                   stroke: "#000",
                   strokeWidth: 1,
                   strokeDasharray: "2 2",
                 }}
-                itemStyle={{color: "#8884d8"}}
+                itemStyle={{ color: "#8884d8" }}
                 formatter={NumberFormatter}
               />
             </AreaChart>
@@ -705,7 +712,7 @@ export default function Main() {
       </AreaChart><li style={{color:'transparent'}}/> */}
             <div
               className={`common-title`}
-              style={{marginBottom: "40px", textAlign: "center"}}
+              style={{ marginBottom: "40px", textAlign: "center" }}
             >
               Distribution / Liquidity
             </div>
@@ -727,9 +734,9 @@ export default function Main() {
                   x2="1"
                   y2="1"
                 >
-                  <stop offset="10%" stopColor="#ba00ff" stopOpacity={0.8}/>
-                  <stop offset="50%" stopColor="#d974ff" stopOpacity={0.1}/>
-                  <stop offset="100%" stopColor="#dc7fff" stopOpacity={0.1}/>
+                  <stop offset="10%" stopColor="#ba00ff" stopOpacity={0.8} />
+                  <stop offset="50%" stopColor="#d974ff" stopOpacity={0.1} />
+                  <stop offset="100%" stopColor="#dc7fff" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <XAxis
@@ -742,7 +749,7 @@ export default function Main() {
               <YAxis
                 axisLine={false}
                 tickFormatter={DataFormater}
-                tick={{fontSize: 16}}
+                tick={{ fontSize: 16 }}
                 stroke="#000"
               />
               <CartesianGrid
@@ -764,13 +771,13 @@ export default function Main() {
                 }}
               />
               <Tooltip
-                content={<CustomTooltip/>}
+                content={<CustomTooltip />}
                 cursor={{
                   stroke: "#000",
                   strokeWidth: 1,
                   strokeDasharray: "2 2",
                 }}
-                itemStyle={{color: "#8884d8"}}
+                itemStyle={{ color: "#8884d8" }}
                 formatter={NumberFormatter}
               />
             </AreaChart>
@@ -782,26 +789,26 @@ export default function Main() {
 
   const renderNarrowMainTable = () => {
     return (
-      <div className="card mb-4 cardbody" style={{minWidth: "300px"}}>
+      <div className="card mb-4 cardbody" style={{ minWidth: "300px" }}>
         <div className="card-body center">
           <table className="textWhiteSmaller">
             <thead>
-            <tr>
-              <th scope="col">Market Cap</th>
-              <th scope="col">
-                Circulating Supply{" "}
-                <span className="">
+              <tr>
+                <th scope="col">Market Cap</th>
+                <th scope="col">
+                  Circulating Supply{" "}
+                  <span className="">
                     <Popup
                       trigger={(open) => (
-                        <span style={{position: "relative", top: "-1px"}}>
-                          <BsFillQuestionCircleFill size={10}/>
+                        <span style={{ position: "relative", top: "-1px" }}>
+                          <BsFillQuestionCircleFill size={10} />
                         </span>
                       )}
                       on="hover"
                       position="left center"
                       offsetY={-23}
                       offsetX={0}
-                      contentStyle={{padding: "3px"}}
+                      contentStyle={{ padding: "3px" }}
                     >
                       <span className="textInfo">
                         {" "}
@@ -809,227 +816,227 @@ export default function Main() {
                       </span>
                     </Popup>
                   </span>
-              </th>
-            </tr>
+                </th>
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <td>
-                $
-                {(
-                  parseFloat(formatUnits(purseTokenTotalSupply, "ether")) *
-                  PURSEPrice
-                ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-              </td>
-              <td>
-                {parseFloat(
-                  formatUnits(purseTokenTotalSupply, "ether")
-                ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-              </td>
-            </tr>
+              <tr>
+                <td>
+                  $
+                  {(
+                    parseFloat(formatUnits(purseTokenTotalSupply, "ether")) *
+                    PURSEPrice
+                  ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                </td>
+                <td>
+                  {parseFloat(
+                    formatUnits(purseTokenTotalSupply, "ether")
+                  ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                </td>
+              </tr>
             </tbody>
             <thead>
-            <tr>
-              <td></td>
-            </tr>
+              <tr>
+                <td></td>
+              </tr>
             </thead>
             <thead>
-            <tr>
-              <th scope="col">
-                Burn (Total)
-                <span className="">
+              <tr>
+                <th scope="col">
+                  Burn (Total)
+                  <span className="">
                     &nbsp;
-                  <Popup
-                    trigger={(open) => (
-                      <span style={{position: "relative", top: "-1px"}}>
-                          <BsFillQuestionCircleFill size={10}/>
+                    <Popup
+                      trigger={(open) => (
+                        <span style={{ position: "relative", top: "-1px" }}>
+                          <BsFillQuestionCircleFill size={10} />
                         </span>
-                    )}
-                    on="hover"
-                    position="bottom center"
-                    offsetY={-23}
-                    offsetX={0}
-                    contentStyle={{padding: "1px"}}
-                  >
+                      )}
+                      on="hover"
+                      position="bottom center"
+                      offsetY={-23}
+                      offsetX={0}
+                      contentStyle={{ padding: "1px" }}
+                    >
                       <span className="textInfo">
                         {" "}
                         (Unit in Token / unit in USD)
                       </span>
                     </Popup>
                   </span>
-              </th>
-              {/*<th scope="col">(Past 30 days&nbsp;Sum)</th>*/}
-            </tr>
+                </th>
+                {/*<th scope="col">(Past 30 days&nbsp;Sum)</th>*/}
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <td>
-                {parseFloat(
-                  formatUnits(totalBurnAmount, "ether")
-                ).toLocaleString("en-US", {
-                  maximumFractionDigits: 0,
-                })}{" "}
-                / ${" "}
-                {(
-                  parseFloat(formatUnits(totalBurnAmount, "ether")) *
-                  PURSEPrice
-                ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-              </td>
-              {/*<td>*/}
-              {/*  {parseFloat(*/}
-              {/*    formatUnits(sum30BurnAmount, "ether")*/}
-              {/*  ).toLocaleString("en-US", {*/}
-              {/*    maximumFractionDigits: 0,*/}
-              {/*  })}{" "}*/}
-              {/*  / ${" "}*/}
-              {/*  {(*/}
-              {/*    parseFloat(formatUnits(sum30BurnAmount, "ether")) **/}
-              {/*    PURSEPrice*/}
-              {/*  ).toLocaleString("en-US", {maximumFractionDigits: 0})}*/}
-              {/*</td>*/}
-            </tr>
+              <tr>
+                <td>
+                  {parseFloat(
+                    formatUnits(totalBurnAmount, "ether")
+                  ).toLocaleString("en-US", {
+                    maximumFractionDigits: 0,
+                  })}{" "}
+                  / ${" "}
+                  {(
+                    parseFloat(formatUnits(totalBurnAmount, "ether")) *
+                    PURSEPrice
+                  ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                </td>
+                {/*<td>*/}
+                {/*  {parseFloat(*/}
+                {/*    formatUnits(sum30BurnAmount, "ether")*/}
+                {/*  ).toLocaleString("en-US", {*/}
+                {/*    maximumFractionDigits: 0,*/}
+                {/*  })}{" "}*/}
+                {/*  / ${" "}*/}
+                {/*  {(*/}
+                {/*    parseFloat(formatUnits(sum30BurnAmount, "ether")) **/}
+                {/*    PURSEPrice*/}
+                {/*  ).toLocaleString("en-US", {maximumFractionDigits: 0})}*/}
+                {/*</td>*/}
+              </tr>
             </tbody>
             <thead>
-            <tr>
-              <td></td>
-            </tr>
+              <tr>
+                <td></td>
+              </tr>
             </thead>
             <thead>
-            <tr>
-              <th scope="col">
-                Distribution (Total)
-                <span className="">
+              <tr>
+                <th scope="col">
+                  Distribution (Total)
+                  <span className="">
                     &nbsp;
-                  <Popup
-                    trigger={(open) => (
-                      <span style={{position: "relative", top: "-1px"}}>
-                          <BsFillQuestionCircleFill size={10}/>
+                    <Popup
+                      trigger={(open) => (
+                        <span style={{ position: "relative", top: "-1px" }}>
+                          <BsFillQuestionCircleFill size={10} />
                         </span>
-                    )}
-                    on="hover"
-                    position="bottom center"
-                    offsetY={-23}
-                    offsetX={0}
-                    contentStyle={{padding: "1px"}}
-                  >
+                      )}
+                      on="hover"
+                      position="bottom center"
+                      offsetY={-23}
+                      offsetX={0}
+                      contentStyle={{ padding: "1px" }}
+                    >
                       <span className="textInfo">
                         {" "}
                         (Unit in Token / unit in USD)
                       </span>
                     </Popup>
                   </span>
-              </th>
-              {/*<th scope="col">(Past 30 days&nbsp;Sum)</th>*/}
-            </tr>
+                </th>
+                {/*<th scope="col">(Past 30 days&nbsp;Sum)</th>*/}
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <td>
-                {parseFloat(
-                  formatUnits(totalTransferAmount, "ether")
-                ).toLocaleString("en-US", {
-                  maximumFractionDigits: 0,
-                })}{" "}
-                / ${" "}
-                {(
-                  parseFloat(formatUnits(totalTransferAmount, "ether")) *
-                  PURSEPrice
-                ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-              </td>
-              {/*<td>*/}
-              {/*  {parseFloat(*/}
-              {/*    formatUnits(sum30TransferAmount, "ether")*/}
-              {/*  ).toLocaleString("en-US", {*/}
-              {/*    maximumFractionDigits: 0,*/}
-              {/*  })}{" "}*/}
-              {/*  / ${" "}*/}
-              {/*  {(*/}
-              {/*    parseFloat(formatUnits(sum30TransferAmount, "ether")) **/}
-              {/*    PURSEPrice*/}
-              {/*  ).toLocaleString("en-US", {maximumFractionDigits: 0})}*/}
-              {/*</td>*/}
-            </tr>
+              <tr>
+                <td>
+                  {parseFloat(
+                    formatUnits(totalTransferAmount, "ether")
+                  ).toLocaleString("en-US", {
+                    maximumFractionDigits: 0,
+                  })}{" "}
+                  / ${" "}
+                  {(
+                    parseFloat(formatUnits(totalTransferAmount, "ether")) *
+                    PURSEPrice
+                  ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                </td>
+                {/*<td>*/}
+                {/*  {parseFloat(*/}
+                {/*    formatUnits(sum30TransferAmount, "ether")*/}
+                {/*  ).toLocaleString("en-US", {*/}
+                {/*    maximumFractionDigits: 0,*/}
+                {/*  })}{" "}*/}
+                {/*  / ${" "}*/}
+                {/*  {(*/}
+                {/*    parseFloat(formatUnits(sum30TransferAmount, "ether")) **/}
+                {/*    PURSEPrice*/}
+                {/*  ).toLocaleString("en-US", {maximumFractionDigits: 0})}*/}
+                {/*</td>*/}
+              </tr>
             </tbody>
             <thead>
-            <tr>
-              <td></td>
-            </tr>
+              <tr>
+                <td></td>
+              </tr>
             </thead>
             <thead>
-            <tr>
-              <th scope="col">
-                Liquidity (Total)
-                <span className="">
+              <tr>
+                <th scope="col">
+                  Liquidity (Total)
+                  <span className="">
                     &nbsp;
-                  <Popup
-                    trigger={(open) => (
-                      <span style={{position: "relative", top: "-1px"}}>
-                          <BsFillQuestionCircleFill size={10}/>
+                    <Popup
+                      trigger={(open) => (
+                        <span style={{ position: "relative", top: "-1px" }}>
+                          <BsFillQuestionCircleFill size={10} />
                         </span>
-                    )}
-                    on="hover"
-                    position="bottom center"
-                    offsetY={-23}
-                    offsetX={0}
-                    contentStyle={{padding: "1px"}}
-                  >
+                      )}
+                      on="hover"
+                      position="bottom center"
+                      offsetY={-23}
+                      offsetX={0}
+                      contentStyle={{ padding: "1px" }}
+                    >
                       <span className="textInfo">
                         {" "}
                         (Unit in Token / unit in USD){" "}
                       </span>
                     </Popup>
                   </span>
-              </th>
-              {/*<th scope="col">(Past 30 days&nbsp;Sum)</th>*/}
-            </tr>
+                </th>
+                {/*<th scope="col">(Past 30 days&nbsp;Sum)</th>*/}
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <td>
-                {parseFloat(
-                  formatUnits(totalTransferAmount, "ether")
-                ).toLocaleString("en-US", {
-                  maximumFractionDigits: 0,
-                })}{" "}
-                / ${" "}
-                {(
-                  parseFloat(formatUnits(totalTransferAmount, "ether")) *
-                  PURSEPrice
-                ).toLocaleString("en-US", {maximumFractionDigits: 0})}
-              </td>
-              {/*<td>*/}
-              {/*  {parseFloat(*/}
-              {/*    formatUnits(sum30TransferAmount, "ether")*/}
-              {/*  ).toLocaleString("en-US", {*/}
-              {/*    maximumFractionDigits: 0,*/}
-              {/*  })}{" "}*/}
-              {/*  / ${" "}*/}
-              {/*  {(*/}
-              {/*    parseFloat(formatUnits(sum30TransferAmount, "ether")) **/}
-              {/*    PURSEPrice*/}
-              {/*  ).toLocaleString("en-US", {maximumFractionDigits: 0})}*/}
-              {/*</td>*/}
-            </tr>
+              <tr>
+                <td>
+                  {parseFloat(
+                    formatUnits(totalTransferAmount, "ether")
+                  ).toLocaleString("en-US", {
+                    maximumFractionDigits: 0,
+                  })}{" "}
+                  / ${" "}
+                  {(
+                    parseFloat(formatUnits(totalTransferAmount, "ether")) *
+                    PURSEPrice
+                  ).toLocaleString("en-US", { maximumFractionDigits: 0 })}
+                </td>
+                {/*<td>*/}
+                {/*  {parseFloat(*/}
+                {/*    formatUnits(sum30TransferAmount, "ether")*/}
+                {/*  ).toLocaleString("en-US", {*/}
+                {/*    maximumFractionDigits: 0,*/}
+                {/*  })}{" "}*/}
+                {/*  / ${" "}*/}
+                {/*  {(*/}
+                {/*    parseFloat(formatUnits(sum30TransferAmount, "ether")) **/}
+                {/*    PURSEPrice*/}
+                {/*  ).toLocaleString("en-US", {maximumFractionDigits: 0})}*/}
+                {/*</td>*/}
+              </tr>
             </tbody>
             <thead>
-            <tr>
-              <td></td>
-            </tr>
+              <tr>
+                <td></td>
+              </tr>
             </thead>
             <thead>
-            <tr>
-              <th scope="col">PURSE Token Price</th>
-            </tr>
+              <tr>
+                <th scope="col">PURSE Token Price</th>
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <td>
-                $
-                {parseFloat(PURSEPrice.toString()).toLocaleString("en-US", {
-                  maximumFractionDigits: 6,
-                })}
-              </td>
-            </tr>
+              <tr>
+                <td>
+                  $
+                  {parseFloat(PURSEPrice.toString()).toLocaleString("en-US", {
+                    maximumFractionDigits: 6,
+                  })}
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -1039,89 +1046,89 @@ export default function Main() {
 
   const renderNarrowFarmTable = () => {
     return (
-      <div className="card mb-2 cardbody" style={{minWidth: "300px"}}>
+      <div className="card mb-2 cardbody" style={{ minWidth: "300px" }}>
         <div className="card-body center">
           <table className="textWhiteSmaller text-center">
             <thead>
-            <tr>
-              <th scope="col">Total Pool</th>
-              <th scope="col">Farm's PURSE Reward</th>
-            </tr>
+              <tr>
+                <th scope="col">Total Pool</th>
+                <th scope="col">Farm's PURSE Reward</th>
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <td>{poolLength}</td>
-              <td>
-                {parseFloat(
-                  formatBigNumber(totalRewardPerBlock, "ether")
-                ).toLocaleString("en-US", {
-                  maximumFractionDigits: 0,
-                })}{" "}
-                Purse per block
-              </td>
-            </tr>
+              <tr>
+                <td>{poolLength}</td>
+                <td>
+                  {parseFloat(
+                    formatBigNumber(totalRewardPerBlock, "ether")
+                  ).toLocaleString("en-US", {
+                    maximumFractionDigits: 0,
+                  })}{" "}
+                  Purse per block
+                </td>
+              </tr>
             </tbody>
             <thead>
-            <tr>
-              <td></td>
-            </tr>
+              <tr>
+                <td></td>
+              </tr>
             </thead>
             <thead>
-            <tr>
-              <th scope="col">PURSE Token Total Supply</th>
-              <th scope="col">Farm's Cap Reward Token</th>
-            </tr>
+              <tr>
+                <th scope="col">PURSE Token Total Supply</th>
+                <th scope="col">Farm's Cap Reward Token</th>
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <td>
-                {parseFloat(
-                  formatBigNumber(purseTokenTotalSupply, "ether")
-                ).toLocaleString("en-US", {
-                  maximumFractionDigits: 0,
-                })}{" "}
-                Purse
-              </td>
-              <td>
-                {parseFloat(
-                  formatBigNumber(poolCapRewardToken, "ether")
-                ).toLocaleString("en-US", {
-                  maximumFractionDigits: 0,
-                })}{" "}
-                Purse
-              </td>
-            </tr>
+              <tr>
+                <td>
+                  {parseFloat(
+                    formatBigNumber(purseTokenTotalSupply, "ether")
+                  ).toLocaleString("en-US", {
+                    maximumFractionDigits: 0,
+                  })}{" "}
+                  Purse
+                </td>
+                <td>
+                  {parseFloat(
+                    formatBigNumber(poolCapRewardToken, "ether")
+                  ).toLocaleString("en-US", {
+                    maximumFractionDigits: 0,
+                  })}{" "}
+                  Purse
+                </td>
+              </tr>
             </tbody>
             <thead>
-            <tr>
-              <td></td>
-            </tr>
+              <tr>
+                <td></td>
+              </tr>
             </thead>
             <thead>
-            <tr>
-              <th scope="col">Farm's Minted Reward Token</th>
-              <th scope="col">Farm's PURSE Balance</th>
-            </tr>
+              <tr>
+                <th scope="col">Farm's Minted Reward Token</th>
+                <th scope="col">Farm's PURSE Balance</th>
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <td>
-                {parseFloat(
-                  formatBigNumber(poolMintedRewardToken, "ether")
-                ).toLocaleString("en-US", {
-                  maximumFractionDigits: 0,
-                })}{" "}
-                Purse
-              </td>
-              <td>
-                {parseFloat(
-                  formatBigNumber(poolRewardToken, "ether")
-                ).toLocaleString("en-US", {
-                  maximumFractionDigits: 0,
-                })}{" "}
-                Purse
-              </td>
-            </tr>
+              <tr>
+                <td>
+                  {parseFloat(
+                    formatBigNumber(poolMintedRewardToken, "ether")
+                  ).toLocaleString("en-US", {
+                    maximumFractionDigits: 0,
+                  })}{" "}
+                  Purse
+                </td>
+                <td>
+                  {parseFloat(
+                    formatBigNumber(poolRewardToken, "ether")
+                  ).toLocaleString("en-US", {
+                    maximumFractionDigits: 0,
+                  })}{" "}
+                  Purse
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -1132,10 +1139,10 @@ export default function Main() {
   const renderNarrowTable = () => {
     return (
       <>
-        <div style={{display: selectedTab === "main" ? "block" : "none"}}>
+        <div style={{ display: selectedTab === "main" ? "block" : "none" }}>
           {renderNarrowMainTable()}
         </div>
-        <div style={{display: selectedTab === "farm" ? "block" : "none"}}>
+        <div style={{ display: selectedTab === "farm" ? "block" : "none" }}>
           {renderNarrowFarmTable()}
         </div>
         {/* <div style={{display: selectedTab === "vault" ? "block" : "none"}}>
@@ -1156,7 +1163,7 @@ export default function Main() {
       >
         <label
           className="textWhite center mb-2 pt-4"
-          style={{fontSize: "40px", textAlign: "center"}}
+          style={{ fontSize: "40px", textAlign: "center" }}
         >
           <big>
             <b>CHARTS</b>
@@ -1177,7 +1184,7 @@ export default function Main() {
             <div>
               <div
                 className={`common-title`}
-                style={{marginBottom: "40px", textAlign: "center"}}
+                style={{ marginBottom: "40px", textAlign: "center" }}
               >
                 Burn
               </div>
@@ -1193,9 +1200,9 @@ export default function Main() {
               >
                 <defs>
                   <linearGradient id="Burn" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="10%" stopColor="#fcdb5b" stopOpacity={0.8}/>
-                    <stop offset="50%" stopColor="#f7e01e" stopOpacity={0.1}/>
-                    <stop offset="100%" stopColor="#ffe95b" stopOpacity={0.1}/>
+                    <stop offset="10%" stopColor="#fcdb5b" stopOpacity={0.8} />
+                    <stop offset="50%" stopColor="#f7e01e" stopOpacity={0.1} />
+                    <stop offset="100%" stopColor="#ffe95b" stopOpacity={0.1} />
                   </linearGradient>
                 </defs>
                 <XAxis
@@ -1208,7 +1215,7 @@ export default function Main() {
                 <YAxis
                   axisLine={false}
                   tickFormatter={DataFormater}
-                  tick={{fontSize: 16}}
+                  tick={{ fontSize: 16 }}
                   stroke="#000"
                 />
                 <CartesianGrid
@@ -1230,13 +1237,13 @@ export default function Main() {
                   }}
                 />
                 <Tooltip
-                  content={<CustomTooltip/>}
+                  content={<CustomTooltip />}
                   cursor={{
                     stroke: "#000",
                     strokeWidth: 1,
                     strokeDasharray: "2 2",
                   }}
-                  itemStyle={{color: "#8884d8"}}
+                  itemStyle={{ color: "#8884d8" }}
                   formatter={NumberFormatter}
                 />
               </AreaChart>
@@ -1257,7 +1264,7 @@ export default function Main() {
           <div>
             <div
               className={`common-title`}
-              style={{marginBottom: "40px", textAlign: "center"}}
+              style={{ marginBottom: "40px", textAlign: "center" }}
             >
               Distribution / Liquidity
             </div>
@@ -1279,9 +1286,9 @@ export default function Main() {
                   x2="1"
                   y2="1"
                 >
-                  <stop offset="10%" stopColor="#ba00ff" stopOpacity={0.8}/>
-                  <stop offset="50%" stopColor="#d974ff" stopOpacity={0.1}/>
-                  <stop offset="100%" stopColor="#dc7fff" stopOpacity={0.1}/>
+                  <stop offset="10%" stopColor="#ba00ff" stopOpacity={0.8} />
+                  <stop offset="50%" stopColor="#d974ff" stopOpacity={0.1} />
+                  <stop offset="100%" stopColor="#dc7fff" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <XAxis
@@ -1294,7 +1301,7 @@ export default function Main() {
               <YAxis
                 axisLine={false}
                 tickFormatter={DataFormater}
-                tick={{fontSize: 16}}
+                tick={{ fontSize: 16 }}
                 stroke="#000"
               />
               <CartesianGrid
@@ -1316,13 +1323,13 @@ export default function Main() {
                 }}
               />
               <Tooltip
-                content={<CustomTooltip/>}
+                content={<CustomTooltip />}
                 cursor={{
                   stroke: "#000",
                   strokeWidth: 1,
                   strokeDasharray: "2 2",
                 }}
-                itemStyle={{color: "#8884d8"}}
+                itemStyle={{ color: "#8884d8" }}
                 formatter={NumberFormatter}
               />
             </AreaChart>
@@ -1342,18 +1349,18 @@ export default function Main() {
       >
         <div
           className="text mt-2 common-title"
-          style={{color: "#000", fontSize: "14px"}}
+          style={{ color: "#000", fontSize: "14px" }}
         >
           &nbsp;Remarks :
         </div>
-        <br/>
+        <br />
         <div
           className="rowC ml-2 mt-2"
-          style={{color: "#000", fontSize: "12px"}}
+          style={{ color: "#000", fontSize: "12px" }}
         >
           &nbsp;
           <div>
-            <IoStar className="mb-1"/>
+            <IoStar className="mb-1" />
             &nbsp;&nbsp;
           </div>
           <div>
@@ -1363,11 +1370,11 @@ export default function Main() {
         </div>
         <div
           className="rowC ml-2 mt-1"
-          style={{color: "#000", fontSize: "12px"}}
+          style={{ color: "#000", fontSize: "12px" }}
         >
           &nbsp;
           <div>
-            <IoStar className="mb-1"/>
+            <IoStar className="mb-1" />
             &nbsp;&nbsp;
           </div>
           <div>
@@ -1377,11 +1384,11 @@ export default function Main() {
         </div>
         <div
           className="rowC ml-2 mt-1"
-          style={{color: "#000", fontSize: "12px"}}
+          style={{ color: "#000", fontSize: "12px" }}
         >
           &nbsp;
           <div>
-            <IoStar className="mb-1"/>
+            <IoStar className="mb-1" />
             &nbsp;&nbsp;
           </div>
           <div>
@@ -1398,7 +1405,7 @@ export default function Main() {
       <>
         <label
           className="textWhite center mb-2 pt-4"
-          style={{fontSize: "40px", textAlign: "center"}}
+          style={{ fontSize: "40px", textAlign: "center" }}
         >
           <big>
             <b>PROTOCOLS</b>
@@ -1416,7 +1423,7 @@ export default function Main() {
             <div className="textWhiteSmall">
               <b>LP Restaking Farm</b>
             </div>
-            <div className="textWhite mt-2" style={{fontSize: "13px"}}>
+            <div className="textWhite mt-2" style={{ fontSize: "13px" }}>
               <b>
                 Providing liquidity on respective platform to receive LP Tokens
                 and earn PURSE by staking the LP Tokens in the LP Restaking
@@ -1437,7 +1444,7 @@ export default function Main() {
             <div className="textWhiteSmall">
               <b>PURSE Staking</b>
             </div>
-            <div className="textWhite mt-2" style={{fontSize: "13px"}}>
+            <div className="textWhite mt-2" style={{ fontSize: "13px" }}>
               <b>Stake PURSE and amplify your earnings with PURSE Staking.</b>
             </div>
           </div>
@@ -1454,24 +1461,24 @@ export default function Main() {
             <div className="textWhiteSmall">
               <b>PURSE BOX</b>
             </div>
-            <div className="textWhite mt-2" style={{fontSize: "13px"}}>
+            <div className="textWhite mt-2" style={{ fontSize: "13px" }}>
               <b>PURSE adopts the experimental ERC404 dual-natured token.</b>
             </div>
           </div>
         </Bounce>
       </>
-    )
-  }
+    );
+  };
 
   return (
     <div
       id="content"
       className="mt-4"
-      style={{margin: "0 auto", maxWidth: "1000px"}}
+      style={{ margin: "0 auto", maxWidth: "1000px" }}
     >
       <label
         className="textWhite center mb-2"
-        style={{fontSize: "40px", textAlign: "center"}}
+        style={{ fontSize: "40px", textAlign: "center" }}
       >
         <big>
           <b>DASHBOARD</b>

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -60,8 +60,13 @@ export function chainId2NetworkName(chainId: number) {
   }
 }
 
-export function timeConverter(UNIX_timestamp: number) {
-  var a = new Date(UNIX_timestamp * 1000);
+export function convertUnixToDate(UNIX_timestamp: number | string) {
+  let numTimestamp =
+    typeof UNIX_timestamp == "string"
+      ? parseInt(UNIX_timestamp as string, 10)
+      : UNIX_timestamp;
+  const a = new Date(numTimestamp * 1000);
+
   var months = [
     "Jan",
     "Feb",
@@ -170,20 +175,28 @@ export const fetcher = (library: any) => (args: any) => {
   return library[method](...params);
 };
 
+export const RawDataFormatter = (number: number) => {
+  return DataFormater(Math.round(number / 10 ** 18));
+};
+
 export const DataFormater = (number: number) => {
   if (number > 1000000000) {
-    return (number / 1000000000).toString() + "B";
+    return Math.round(number / 1000000000).toString() + "B";
   } else if (number > 1000000) {
-    return (number / 1000000).toString() + "M";
+    return Math.round(number / 1000000).toString() + "M";
   } else if (number > 1000) {
-    return (number / 1000).toString() + "K";
+    return Math.round(number / 1000).toString() + "K";
   } else {
     return number.toString();
   }
 };
 
-export const NumberFormatter = (number: string) => {
-  return parseFloat(number).toLocaleString("en-US", {
+export const RawNumberFormatter = (number: number) => {
+  return NumberFormatter(Math.round(number / 10 ** 18));
+};
+
+export const NumberFormatter = (number: number) => {
+  return number.toLocaleString("en-US", {
     maximumFractionDigits: 2,
   });
 };

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -49,6 +49,9 @@ export const MONGO_RESPONSE_1_API = `https://ap-southeast-1.aws.data.mongodb-api
 export const MONGO_RESPONSE_2_API = `https://ap-southeast-1.aws.data.mongodb-api.com/app/data-rjjms/endpoint/CumulativeBurn`;
 export const MONGO_FXSWAP_RESPONSE_API = `https://ap-southeast-1.aws.data.mongodb-api.com/app/data-rjjms/endpoint/tvl_prod`;
 
+export const SUBGRAPH_API =
+  "https://api.goldsky.com/api/public/project_clz6ti9bm1qjm01086dflgsh3/subgraphs/pursetoken/v0.0.2/gn";
+
 //RPC URLs
 export const WALLETCONNECT_BRIDGE_URL =
   "https://wallet-connect.pundix.com/bridge/";

--- a/src/pages/Reward/index.tsx
+++ b/src/pages/Reward/index.tsx
@@ -5,7 +5,7 @@ import { isAddress, getAddress } from "ethers/lib/utils";
 import { BigNumber } from "ethers";
 import * as Constants from "../../constants";
 import {
-  timeConverter,
+  convertUnixToDate,
   callContract,
   getShortTxHash,
   getMerkleProofUserAmount,
@@ -527,8 +527,8 @@ export default function Rewards() {
                     </tr>
                   ) : (
                     <tr>
-                      <td>{timeConverter(rewardsStartTime)}</td>
-                      <td>{timeConverter(rewardsEndTime)}</td>
+                      <td>{convertUnixToDate(rewardsStartTime)}</td>
+                      <td>{convertUnixToDate(rewardsEndTime)}</td>
                     </tr>
                   )}
                 </tbody>


### PR DESCRIPTION
As per title:
- Updated components/main/index.tsx to fetch burn/liquidity data from Goldsky subgraph endpoint.
- Updated recharts components to match. Screenshot:
<img width="1021" alt="Screenshot 2024-09-20 at 1 38 14 PM" src="https://github.com/user-attachments/assets/25035c8c-bce5-4e05-9f62-7f9ad8beb882">
