### PR TITLE
remove minWidth for mintContainer to address footer bug

### DIFF
--- a/src/pages/PurseBox/index.tsx
+++ b/src/pages/PurseBox/index.tsx
@@ -304,8 +304,7 @@ const MintContainer = () => {
           justifyContent: "center",
           margin: "40px auto 0 auto",
           padding: "1%",
-          width: "50%",
-          minWidth: "535px",
+          width: "100%",
           maxWidth: "565px",
           border: "2px inset grey",
           borderRadius: "10px",
@@ -504,9 +503,9 @@ const MintContainer = () => {
                 </div>
               ) : null}
             </div>
-            <div style={{ margin: "1% 0" }}>
+            <div style={{ margin: "1% 0", justifyItems: "space-between" }}>
               <input
-                style={{ width: "85%", verticalAlign: "middle" }}
+                style={{ width: "75%", verticalAlign: "middle" }}
                 type="number"
                 min="0"
                 value={mintAmount}
@@ -516,7 +515,7 @@ const MintContainer = () => {
               <Button
                 variant="outline-primary"
                 style={{
-                  width: "15%",
+                  width: "20%",
                   height: "100%",
                   color: "#ba00ff",
                 }}
@@ -559,8 +558,7 @@ const MintContainer = () => {
           display: "flex",
           margin: "3% auto 0 auto",
           padding: "1%",
-          width: "50%",
-          minWidth: "535px",
+          width: "100%",
           maxWidth: "565px",
           border: "1px inset grey",
         }}


### PR DESCRIPTION
Addresses https://github.com/FunctionX-SG/PurseToken-Interface/issues/55

Changelog:
- Removes minWidth for the mint container in purseBox page.

Screenshots:

Old: 
<img width="317" alt="Screenshot 2024-10-22 at 5 33 03 PM" src="https://github.com/user-attachments/assets/d6662333-8629-44ad-9d50-33701ec790d1">

New:
<img width="298" alt="Screenshot 2024-10-22 at 5 32 21 PM" src="https://github.com/user-attachments/assets/83e11039-cb69-44c6-8ebe-c140e44212eb">
